### PR TITLE
feat: add `code` icon in editor

### DIFF
--- a/src/lib/components/shared/text_editor.svelte
+++ b/src/lib/components/shared/text_editor.svelte
@@ -6,6 +6,7 @@
     import Italic from "$icons/italic.svelte";
     import Strike from "$icons/strike.svelte";
     import Underline from "$icons/underline.svelte";
+    import Code from "$icons/code.svelte";
     import { offset } from "caret-pos";
     import { tick } from "svelte";
     import type { SvelteComponentDev } from "svelte/internal";
@@ -362,6 +363,15 @@
             },
             icon: {
                 component: Strike,
+                class: "w-5 md:w-[1.5vw] text-surface-200"
+            }
+        },
+        code: {
+            function: (element) => {
+                code_text(element as HTMLTextAreaElement)
+            },
+            icon: {
+                component: Code,
                 class: "w-5 md:w-[1.5vw] text-surface-200"
             }
         },

--- a/src/lib/icons/code.svelte
+++ b/src/lib/icons/code.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+    import type { SVGAttributes } from "svelte/elements";
+
+    type $$Props = SVGAttributes<SVGElement>;
+</script>
+
+<svg
+    {...$$props}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+>
+    <path
+        d="M8 8L3 12L8 16M16 16L21 12L16 8"
+        stroke="currentColor"
+        stroke-width="2"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+    />
+</svg>


### PR DESCRIPTION
![Screenshot from 2023-06-18 01-51-12](https://github.com/tokitou-san/CoreProject-V3-UI/assets/114811070/ce98dcd3-f0aa-4554-80d0-73fd748228f1)
