### PR TITLE
add `marked-emoji`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
                 "html-entities": "^2.3.6",
                 "lodash": "^4.17.21",
                 "marked": "^5.1.0",
+                "marked-emoji": "^1.1.1",
                 "nprogress": "^0.2.0",
                 "postcss": "^8.4.24",
                 "prettier": "^2.8.8",
@@ -4222,6 +4223,15 @@
             },
             "engines": {
                 "node": ">= 18"
+            }
+        },
+        "node_modules/marked-emoji": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/marked-emoji/-/marked-emoji-1.1.1.tgz",
+            "integrity": "sha512-li07eazrwR/urek+FJ3EdUINitHdqyCYzJRLvGP05a8tJfKcjcQ/rtu3rcRT76v8MvNMXyjTNX6lHz+JPplHkw==",
+            "dev": true,
+            "peerDependencies": {
+                "marked": "^4 || ^5"
             }
         },
         "node_modules/md5-hex": {
@@ -9814,6 +9824,13 @@
             "resolved": "https://registry.npmjs.org/marked/-/marked-5.1.0.tgz",
             "integrity": "sha512-z3/nBe7aTI8JDszlYLk7dDVNpngjw0o1ZJtrA9kIfkkHcIF+xH7mO23aISl4WxP83elU+MFROgahqdpd05lMEQ==",
             "dev": true
+        },
+        "marked-emoji": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/marked-emoji/-/marked-emoji-1.1.1.tgz",
+            "integrity": "sha512-li07eazrwR/urek+FJ3EdUINitHdqyCYzJRLvGP05a8tJfKcjcQ/rtu3rcRT76v8MvNMXyjTNX6lHz+JPplHkw==",
+            "dev": true,
+            "requires": {}
         },
         "md5-hex": {
             "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
         "html-entities": "^2.3.6",
         "lodash": "^4.17.21",
         "marked": "^5.1.0",
+        "marked-emoji": "^1.1.1",
         "nprogress": "^0.2.0",
         "postcss": "^8.4.24",
         "prettier": "^2.8.8",

--- a/src/lib/components/shared/markdown.svelte
+++ b/src/lib/components/shared/markdown.svelte
@@ -1,11 +1,18 @@
 <script lang="ts">
+    import { emojis } from "$data/emojis";
     import { marked } from "marked";
+    import { markedEmoji } from "marked-emoji";
     import xss from "xss";
 
     export let markdown = "";
     export { klass as class };
 
     let klass = "";
+
+    const emoji_options = {
+        emojis,
+        unicode: false
+    };
 
     // Override function
     const renderer: marked.RendererObject = {
@@ -19,7 +26,15 @@
         }
     };
 
-    marked.use({ renderer });
+    marked.use(
+        // Emoji plugin
+        markedEmoji(emoji_options),
+        {
+            // Disable it as marked-mangle doesn't support typescript
+            mangle: false,
+            renderer
+        }
+    );
 
     let html: string;
     $: html = xss(marked.parse(markdown));


### PR DESCRIPTION
 Now that `marked-emoji` supports typescript we should add it to `animecore` 

check : 
* https://github.com/UziTech/marked-emoji/issues/78
* https://github.com/UziTech/marked-emoji/pull/90