### PR TITLE
Export sanitize to a function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
             "workspaces": [
                 "./scripts"
             ],
+            "dependencies": {
+                "xss": "^1.0.14"
+            },
             "devDependencies": {
                 "@felte/reporter-svelte": "^1.1.10",
                 "@felte/validator-zod": "^1.0.16",
@@ -2146,6 +2149,11 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/cssfilter": {
+            "version": "0.0.10",
+            "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
+            "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
         },
         "node_modules/cssstyle": {
             "version": "3.0.0",
@@ -6500,6 +6508,26 @@
             "version": "2.2.0",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/xss": {
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
+            "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
+            "dependencies": {
+                "commander": "^2.20.3",
+                "cssfilter": "0.0.10"
+            },
+            "bin": {
+                "xss": "bin/xss"
+            },
+            "engines": {
+                "node": ">= 0.10.0"
+            }
+        },
+        "node_modules/xss/node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
         },
         "node_modules/yallist": {
             "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,6 @@
             "workspaces": [
                 "./scripts"
             ],
-            "dependencies": {
-                "xss": "^1.0.14"
-            },
             "devDependencies": {
                 "@felte/reporter-svelte": "^1.1.10",
                 "@felte/validator-zod": "^1.0.16",
@@ -45,7 +42,6 @@
                 "felte": "^1.2.11",
                 "highlight.js": "^11.8.0",
                 "html-entities": "^2.4.0",
-                "isomorphic-dompurify": "^1.8.0",
                 "lodash": "^4.17.21",
                 "marked": "^5.1.1",
                 "marked-emoji": "^1.2.0",
@@ -67,7 +63,8 @@
                 "typescript": "^5.1.6",
                 "vite": "^4.4.4",
                 "vitest": "^0.33.0",
-                "voca": "^1.4.1"
+                "voca": "^1.4.1",
+                "xss": "^1.0.14"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -726,20 +723,6 @@
                 "fsevents": "2.3.2"
             }
         },
-        "node_modules/@playwright/test/node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
         "node_modules/@polka/url": {
             "version": "1.0.0-next.21",
             "dev": true,
@@ -1036,6 +1019,8 @@
             "version": "2.0.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 10"
             }
@@ -1082,15 +1067,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/dompurify": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.2.tgz",
-            "integrity": "sha512-YBL4ziFebbbfQfH5mlC+QTJsvh0oJUrWbmxKMyEdL7emlHJqGR2Qb34TEFKj+VCayBvjKy3xczMFNhugThUsfQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/trusted-types": "*"
-            }
-        },
         "node_modules/@types/estree": {
             "version": "1.0.0",
             "dev": true,
@@ -1136,12 +1112,6 @@
             "version": "7.5.0",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/trusted-types": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.3.tgz",
-            "integrity": "sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==",
-            "dev": true
         },
         "node_modules/@types/voca": {
             "version": "1.4.2",
@@ -1485,7 +1455,9 @@
         "node_modules/abab": {
             "version": "2.0.6",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "optional": true,
+            "peer": true
         },
         "node_modules/abbrev": {
             "version": "1.1.1",
@@ -1647,7 +1619,9 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/autoprefixer": {
             "version": "10.4.14",
@@ -1957,20 +1931,6 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/chokidar/node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
         "node_modules/chokidar/node_modules/glob-parent": {
             "version": "5.1.2",
             "dev": true,
@@ -2059,6 +2019,8 @@
             "version": "1.0.8",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -2153,12 +2115,15 @@
         "node_modules/cssfilter": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/cssfilter/-/cssfilter-0.0.10.tgz",
-            "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw=="
+            "integrity": "sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==",
+            "dev": true
         },
         "node_modules/cssstyle": {
             "version": "3.0.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "rrweb-cssom": "^0.6.0"
             },
@@ -2178,6 +2143,8 @@
             "version": "4.0.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "abab": "^2.0.6",
                 "whatwg-mimetype": "^3.0.0",
@@ -2191,6 +2158,8 @@
             "version": "4.1.1",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "punycode": "^2.3.0"
             },
@@ -2202,6 +2171,8 @@
             "version": "7.0.0",
             "dev": true,
             "license": "BSD-2-Clause",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -2210,6 +2181,8 @@
             "version": "12.0.1",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "tr46": "^4.1.1",
                 "webidl-conversions": "^7.0.0"
@@ -2242,7 +2215,9 @@
         "node_modules/decimal.js": {
             "version": "10.4.3",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/decompress-response": {
             "version": "6.0.0",
@@ -2294,6 +2269,8 @@
             "version": "1.0.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -2376,6 +2353,8 @@
             "version": "4.0.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "webidl-conversions": "^7.0.0"
             },
@@ -2387,15 +2366,11 @@
             "version": "7.0.0",
             "dev": true,
             "license": "BSD-2-Clause",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
-        },
-        "node_modules/dompurify": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.0.5.tgz",
-            "integrity": "sha512-F9e6wPGtY+8KNMRAVfxeCOHU0/NPWMSENNq4pQctuXRqqdEPW7q3CrLbR5Nse044WwacyjHGOMlvNsBe1y6z9A==",
-            "dev": true
         },
         "node_modules/easytimer.js": {
             "version": "4.5.4",
@@ -2419,6 +2394,8 @@
             "version": "4.5.0",
             "dev": true,
             "license": "BSD-2-Clause",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=0.12"
             },
@@ -2465,342 +2442,6 @@
                 "@esbuild/win32-arm64": "0.18.11",
                 "@esbuild/win32-ia32": "0.18.11",
                 "@esbuild/win32-x64": "0.18.11"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/android-arm": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.11.tgz",
-            "integrity": "sha512-q4qlUf5ucwbUJZXF5tEQ8LF7y0Nk4P58hOsGk3ucY0oCwgQqAnqXVbUuahCddVHfrxmpyewRpiTHwVHIETYu7Q==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/android-arm64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.11.tgz",
-            "integrity": "sha512-snieiq75Z1z5LJX9cduSAjUr7vEI1OdlzFPMw0HH5YI7qQHDd3qs+WZoMrWYDsfRJSq36lIA6mfZBkvL46KoIw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/android-x64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.11.tgz",
-            "integrity": "sha512-iPuoxQEV34+hTF6FT7om+Qwziv1U519lEOvekXO9zaMMlT9+XneAhKL32DW3H7okrCOBQ44BMihE8dclbZtTuw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.11.tgz",
-            "integrity": "sha512-Gm0QkI3k402OpfMKyQEEMG0RuW2LQsSmI6OeO4El2ojJMoF5NLYb3qMIjvbG/lbMeLOGiW6ooU8xqc+S0fgz2w==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/darwin-x64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.11.tgz",
-            "integrity": "sha512-N15Vzy0YNHu6cfyDOjiyfJlRJCB/ngKOAvoBf1qybG3eOq0SL2Lutzz9N7DYUbb7Q23XtHPn6lMDF6uWbGv9Fw==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.11.tgz",
-            "integrity": "sha512-atEyuq6a3omEY5qAh5jIORWk8MzFnCpSTUruBgeyN9jZq1K/QI9uke0ATi3MHu4L8c59CnIi4+1jDKMuqmR71A==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.11.tgz",
-            "integrity": "sha512-XtuPrEfBj/YYYnAAB7KcorzzpGTvOr/dTtXPGesRfmflqhA4LMF0Gh/n5+a9JBzPuJ+CGk17CA++Hmr1F/gI0Q==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/linux-arm": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.11.tgz",
-            "integrity": "sha512-Idipz+Taso/toi2ETugShXjQ3S59b6m62KmLHkJlSq/cBejixmIydqrtM2XTvNCywFl3VC7SreSf6NV0i6sRyg==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/linux-arm64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.11.tgz",
-            "integrity": "sha512-c6Vh2WS9VFKxKZ2TvJdA7gdy0n6eSy+yunBvv4aqNCEhSWVor1TU43wNRp2YLO9Vng2G+W94aRz+ILDSwAiYog==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/linux-ia32": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.11.tgz",
-            "integrity": "sha512-S3hkIF6KUqRh9n1Q0dSyYcWmcVa9Cg+mSoZEfFuzoYXXsk6196qndrM+ZiHNwpZKi3XOXpShZZ+9dfN5ykqjjw==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/linux-loong64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.11.tgz",
-            "integrity": "sha512-MRESANOoObQINBA+RMZW+Z0TJWpibtE7cPFnahzyQHDCA9X9LOmGh68MVimZlM9J8n5Ia8lU773te6O3ILW8kw==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.11.tgz",
-            "integrity": "sha512-qVyPIZrXNMOLYegtD1u8EBccCrBVshxMrn5MkuFc3mEVsw7CCQHaqZ4jm9hbn4gWY95XFnb7i4SsT3eflxZsUg==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.11.tgz",
-            "integrity": "sha512-T3yd8vJXfPirZaUOoA9D2ZjxZX4Gr3QuC3GztBJA6PklLotc/7sXTOuuRkhE9W/5JvJP/K9b99ayPNAD+R+4qQ==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.11.tgz",
-            "integrity": "sha512-evUoRPWiwuFk++snjH9e2cAjF5VVSTj+Dnf+rkO/Q20tRqv+644279TZlPK8nUGunjPAtQRCj1jQkDAvL6rm2w==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/linux-s390x": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.11.tgz",
-            "integrity": "sha512-/SlRJ15XR6i93gRWquRxYCfhTeC5PdqEapKoLbX63PLCmAkXZHY2uQm2l9bN0oPHBsOw2IswRZctMYS0MijFcg==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/linux-x64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.11.tgz",
-            "integrity": "sha512-xcncej+wF16WEmIwPtCHi0qmx1FweBqgsRtEL1mSHLFR6/mb3GEZfLQnx+pUDfRDEM4DQF8dpXIW7eDOZl1IbA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.11.tgz",
-            "integrity": "sha512-aSjMHj/F7BuS1CptSXNg6S3M4F3bLp5wfFPIJM+Km2NfIVfFKhdmfHF9frhiCLIGVzDziggqWll0B+9AUbud/Q==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.11.tgz",
-            "integrity": "sha512-tNBq+6XIBZtht0xJGv7IBB5XaSyvYPCm1PxJ33zLQONdZoLVM0bgGqUrXnJyiEguD9LU4AHiu+GCXy/Hm9LsdQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/sunos-x64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.11.tgz",
-            "integrity": "sha512-kxfbDOrH4dHuAAOhr7D7EqaYf+W45LsAOOhAet99EyuxxQmjbk8M9N4ezHcEiCYPaiW8Dj3K26Z2V17Gt6p3ng==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/win32-arm64": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.11.tgz",
-            "integrity": "sha512-Sh0dDRyk1Xi348idbal7lZyfSkjhJsdFeuC13zqdipsvMetlGiFQNdO+Yfp6f6B4FbyQm7qsk16yaZk25LChzg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/esbuild/node_modules/@esbuild/win32-ia32": {
-            "version": "0.18.11",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.11.tgz",
-            "integrity": "sha512-o9JUIKF1j0rqJTFbIoF4bXj6rvrTZYOrfRcGyL0Vm5uJ/j5CkBD/51tpdxe9lXEDouhRgdr/BYzUrDOvrWwJpg==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=12"
             }
         },
         "node_modules/escalade": {
@@ -3263,6 +2904,8 @@
             "version": "4.0.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
@@ -3505,6 +3148,8 @@
             "version": "3.0.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "whatwg-encoding": "^2.0.0"
             },
@@ -3531,6 +3176,8 @@
             "version": "5.0.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "@tootallnate/once": "2",
                 "agent-base": "6",
@@ -3556,6 +3203,8 @@
             "version": "0.6.3",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "safer-buffer": ">= 2.1.2 < 3.0.0"
             },
@@ -3721,7 +3370,9 @@
         "node_modules/is-potential-custom-element-name": {
             "version": "1.0.1",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/is-reference": {
             "version": "1.2.1",
@@ -3735,17 +3386,6 @@
             "version": "2.0.0",
             "dev": true,
             "license": "ISC"
-        },
-        "node_modules/isomorphic-dompurify": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-1.8.0.tgz",
-            "integrity": "sha512-qvNsRVUQIArrn7/TNDw0+0wQgtvRxAkSzfe0pGpX1+OYeGhrAWELxZIb6x+KFFRS6mb4OUe+zAK9yp0WDZHUdQ==",
-            "dev": true,
-            "dependencies": {
-                "@types/dompurify": "^3.0.2",
-                "dompurify": "^3.0.5",
-                "jsdom": "^22.1.0"
-            }
         },
         "node_modules/javascript-natural-sort": {
             "version": "0.7.1",
@@ -3784,6 +3424,8 @@
             "version": "22.1.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "abab": "^2.0.6",
                 "cssstyle": "^3.0.0",
@@ -3825,6 +3467,8 @@
             "version": "4.1.1",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "punycode": "^2.3.0"
             },
@@ -3836,6 +3480,8 @@
             "version": "7.0.0",
             "dev": true,
             "license": "BSD-2-Clause",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -3844,6 +3490,8 @@
             "version": "12.0.1",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "tr46": "^4.1.1",
                 "webidl-conversions": "^7.0.0"
@@ -4093,6 +3741,8 @@
             "version": "1.52.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -4101,6 +3751,8 @@
             "version": "2.1.35",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -4398,7 +4050,9 @@
         "node_modules/nwsapi": {
             "version": "2.2.5",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
@@ -4483,6 +4137,8 @@
             "version": "7.1.2",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "entities": "^4.4.0"
             },
@@ -4962,7 +4618,9 @@
         "node_modules/psl": {
             "version": "1.9.0",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/pump": {
             "version": "3.0.0",
@@ -4984,7 +4642,9 @@
         "node_modules/querystringify": {
             "version": "2.2.0",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -5072,7 +4732,9 @@
         "node_modules/requires-port": {
             "version": "1.0.0",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/resolve": {
             "version": "1.22.2",
@@ -5136,24 +4798,12 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/rollup/node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
-        },
         "node_modules/rrweb-cssom": {
             "version": "0.6.0",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
@@ -5210,7 +4860,9 @@
         "node_modules/safer-buffer": {
             "version": "2.1.2",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/sander": {
             "version": "0.5.1",
@@ -5254,6 +4906,8 @@
             "version": "6.0.0",
             "dev": true,
             "license": "ISC",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "xmlchars": "^2.2.0"
             },
@@ -5806,7 +5460,9 @@
         "node_modules/symbol-tree": {
             "version": "3.2.4",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/tailwind-scrollbar": {
             "version": "3.0.4",
@@ -6012,6 +5668,8 @@
             "version": "4.1.3",
             "dev": true,
             "license": "BSD-3-Clause",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "psl": "^1.1.33",
                 "punycode": "^2.1.1",
@@ -6121,6 +5779,8 @@
             "version": "0.2.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -6162,6 +5822,8 @@
             "version": "1.5.10",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "querystringify": "^2.1.1",
                 "requires-port": "^1.0.0"
@@ -6246,20 +5908,6 @@
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
-            }
-        },
-        "node_modules/vite/node_modules/fsevents": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-            "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
         },
         "node_modules/vitefu": {
@@ -6360,6 +6008,8 @@
             "version": "4.0.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "xml-name-validator": "^4.0.0"
             },
@@ -6384,6 +6034,8 @@
             "version": "2.0.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "dependencies": {
                 "iconv-lite": "0.6.3"
             },
@@ -6395,6 +6047,8 @@
             "version": "3.0.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -6480,6 +6134,8 @@
             "version": "8.13.0",
             "dev": true,
             "license": "MIT",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -6500,6 +6156,8 @@
             "version": "4.0.0",
             "dev": true,
             "license": "Apache-2.0",
+            "optional": true,
+            "peer": true,
             "engines": {
                 "node": ">=12"
             }
@@ -6507,12 +6165,15 @@
         "node_modules/xmlchars": {
             "version": "2.2.0",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "optional": true,
+            "peer": true
         },
         "node_modules/xss": {
             "version": "1.0.14",
             "resolved": "https://registry.npmjs.org/xss/-/xss-1.0.14.tgz",
             "integrity": "sha512-og7TEJhXvn1a7kzZGQ7ETjdQVS2UfZyTlsEdDOqvQF7GoxNfY+0YLCzBy1kPdsDDx4QuNAonQPddpsn6Xl/7sw==",
+            "dev": true,
             "dependencies": {
                 "commander": "^2.20.3",
                 "cssfilter": "0.0.10"
@@ -6527,7 +6188,8 @@
         "node_modules/xss/node_modules/commander": {
             "version": "2.20.3",
             "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true
         },
         "node_modules/yallist": {
             "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -69,13 +69,12 @@
         "typescript": "^5.1.6",
         "vite": "^4.4.4",
         "vitest": "^0.33.0",
-        "voca": "^1.4.1"
+        "voca": "^1.4.1",
+        "xss": "^1.0.14"
     },
     "type": "module",
     "workspaces": [
         "./scripts"
     ],
-    "dependencies": {
-        "xss": "^1.0.14"
-    }
+    "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
         "felte": "^1.2.11",
         "highlight.js": "^11.8.0",
         "html-entities": "^2.4.0",
-        "isomorphic-dompurify": "^1.8.0",
         "lodash": "^4.17.21",
         "marked": "^5.1.1",
         "marked-emoji": "^1.2.0",
@@ -75,5 +74,8 @@
     "type": "module",
     "workspaces": [
         "./scripts"
-    ]
+    ],
+    "dependencies": {
+        "xss": "^1.0.14"
+    }
 }

--- a/src/lib/components/shared/markdown.svelte
+++ b/src/lib/components/shared/markdown.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
     import { emojis } from "$data/emojis";
+    import { sanitize } from "$functions/sanitize";
     import hljs from "highlight.js";
     import "highlight.js/scss/github-dark.scss";
-    import DOMPurify from "isomorphic-dompurify";
     import type { marked as markedType } from "marked";
     import { Marked } from "marked";
     import type { MarkedEmojiOptions } from "marked-emoji";
@@ -47,7 +47,7 @@
     );
 
     let html: string;
-    $: html = DOMPurify.sanitize(marked.parse(markdown));
+    $: html = sanitize(marked.parse(markdown));
 </script>
 
 <markdown class={klass}>

--- a/src/lib/components/shared/text_editor.svelte
+++ b/src/lib/components/shared/text_editor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
     import ImageLoader from "$components/shared/image/image_loader.svelte";
     import { emojis } from "$data/emojis";
+    import { sanitize } from "$functions/sanitize";
     import Bold from "$icons/bold.svelte";
     import Code from "$icons/code.svelte";
     import Hyperlink from "$icons/hyperlink.svelte";
@@ -9,7 +10,6 @@
     import Underline from "$icons/underline.svelte";
     import Markdown from "./markdown.svelte";
     import { offset } from "caret-pos";
-    import DOMPurify from "isomorphic-dompurify";
     import { tick } from "svelte";
     import type { SvelteComponent } from "svelte";
     import tippy from "tippy.js";
@@ -420,7 +420,7 @@
                     type="button"
                     aria-label={item_label}
                     use:tippy={{
-                        content: `<div class='leading-2 w-max whitespace-nowrap rounded-lg bg-surface-400 px-2 py-1 text-[0.65rem] text-surface-50 md:px-[0.75vw] md:py-[0.3vw] md:text-[1vw]'>${DOMPurify.sanitize(description)}</div>`,
+                        content: `<div class='leading-2 w-max whitespace-nowrap rounded-lg bg-surface-400 px-2 py-1 text-[0.65rem] text-surface-50 md:px-[0.75vw] md:py-[0.3vw] md:text-[1vw]'>${sanitize(description)}</div>`,
                         allowHTML: true,
                         arrow: false,
                         offset: [0, 17],

--- a/src/lib/functions/sanitize.test.ts
+++ b/src/lib/functions/sanitize.test.ts
@@ -3,8 +3,8 @@ import { expect, test } from "vitest";
 
 test("sanitize function", () => {
     const html = `<h1>hello world <script>console.log('sora amamiya is the best')</script></h1>`;
-    expect(sanitize(html)).toBe(`<h1>hello world </h1>`);
+    expect(sanitize(html)).toBe(`<h1>hello world &lt;script&gt;console.log('sora amamiya is the best')&lt;/script&gt;</h1>`);
 
     const image_src = `<img src='#' onerror=alert(1) />`;
-    expect(sanitize(image_src)).toBe(`<img src="#">`);
+    expect(sanitize(image_src)).toBe(`<img src="#" />`);
 });

--- a/src/lib/functions/sanitize.test.ts
+++ b/src/lib/functions/sanitize.test.ts
@@ -1,0 +1,10 @@
+import { sanitize } from "$functions/sanitize";
+import { expect, test } from "vitest";
+
+test("sanitize function", () => {
+    const html = `<h1>hello world <script>console.log('sora amamiya is the best')</script></h1>`;
+    expect(sanitize(html)).toBe(`<h1>hello world </h1>`);
+
+    const image_src = `<img src='#' onerror=alert(1) />`;
+    expect(sanitize(image_src)).toBe(`<img src="#">`);
+});

--- a/src/lib/functions/sanitize.ts
+++ b/src/lib/functions/sanitize.ts
@@ -1,5 +1,25 @@
-import DOMPurify from "isomorphic-dompurify";
+import xss from "xss";
 
 export function sanitize(text: string) {
-    return DOMPurify.sanitize(text);
+    return xss(text, {
+        whiteList: {
+            del: ["class"],
+            p: ["class"],
+            strong: ["class"],
+            em: ["class"],
+            b: ["class"],
+            a: ["href", "class"],
+            u: ["class"],
+            i: ["class"],
+            img: ["src"],
+            code: ["class"],
+            pre: ["class"],
+            span: ["class"],
+            h1: ["class"],
+            h2: ["class"],
+            h3: ["class"],
+            h4: ["class"],
+            h5: ["class"]
+        }
+    });
 }

--- a/src/lib/functions/sanitize.ts
+++ b/src/lib/functions/sanitize.ts
@@ -1,0 +1,5 @@
+import DOMPurify from "isomorphic-dompurify";
+
+export function sanitize(text: string) {
+    return DOMPurify.sanitize(text);
+}


### PR DESCRIPTION
Shipping  over `1.5MB` for a dependency is not the right approach for us. Since we are optimizing for speed. Putting something that large over our hottest routes is the single worst thing we can do.