### PR TITLE
fix: export line clamp as class

### DIFF
--- a/src/lib/components/pages/anime_info/index.svelte
+++ b/src/lib/components/pages/anime_info/index.svelte
@@ -389,7 +389,7 @@
 
                                         height="max-h-9 md:max-h-[1.25vw] md:hover:max-h-[18vw]"
                                         duration="duration-500"
-                                        line_clamp={2}
+                                        line_clamp="line-clamp-2"
                                     >
                                         {title}
                                     </HoverExpand>

--- a/src/lib/components/shared/hover_expand.svelte
+++ b/src/lib/components/shared/hover_expand.svelte
@@ -6,11 +6,11 @@
     export { klass as class };
     export let height: string = "";
     export let duration: string = "duration-300";
-    export let line_clamp: number = 1;
+    export let line_clamp: string = "line-clamp-1";
 </script>
 
-<ScrollArea class="{cn( klass, height, duration )} overflow-hidden ease-in-out scrollbar-none hover:overflow-y-scroll">
-    <span class="line-clamp-{line_clamp} md:line-clamp-none mask-right">
+<ScrollArea class={cn(klass, height, duration, "overflow-hidden ease-in-out scrollbar-none hover:overflow-y-scroll")}>
+    <span class={cn(line_clamp, "md:line-clamp-none mask-right")}>
         <slot />
     </span>
 </ScrollArea>


### PR DESCRIPTION
Exported `line_clamp` as class, cant include in `klass` coz of some masking issues.
also we're already exporting `duration` and `height` seperatly, so I dont think this is bad at all.
Closes #675 