### PR TITLE
feat: New function to get accurate page url

### DIFF
--- a/src/lib/components/pages/anime_info/error.svelte
+++ b/src/lib/components/pages/anime_info/error.svelte
@@ -5,6 +5,8 @@
     import { onMount } from "svelte";
     import { blur } from "svelte/transition";
     import { fish_mapping } from "$data/fish_mapping";
+    import { get_page_from_url } from "$functions/urls/get_page_from_url";
+    import { page } from "$app/stores";
 
     let mapping: (typeof fish_mapping)[0] | undefined;
 
@@ -53,7 +55,7 @@
                 {@html format_kokoro_color(`Uh-oh looks like our kokoro-chan is working really hard for the past few days and now has fall asleep. You can wait for her to wake up by looking at the status page, or come say hi to other fellow kokoro-chan's worksippers! ah- also let's wish her sweat dreams!`)}
             </context>
             <a
-                href="../explore"
+                href="{get_page_from_url($page.url.pathname)}/explore"
                 class="btn mt-5 w-max gap-2 bg-primary-500 py-4 font-semibold leading-none md:mt-0 md:gap-[0.5vw] md:py-[1vw] md:text-[1.1vw]"
             >
                 Explore animes

--- a/src/lib/components/pages/anime_info/index.svelte
+++ b/src/lib/components/pages/anime_info/index.svelte
@@ -30,7 +30,7 @@
     import Comment from "$components/shared/comment.svelte";
     import { page } from "$app/stores";
     import HoverExpand from "$components/shared/hover_expand.svelte";
-    import { remove_slash_from_end } from "$functions/urls/remove_slash_at_end";
+    import { get_page_from_url } from "$functions/urls/get_page_from_url";
 
     export let anime_id: number, anime_episodes: any, anime_name: string, japanese_name: string, anime_episodes_count: number, anime_date: string, anime_synopsis: string, anime_banner: string, anime_cover: string;
 
@@ -360,7 +360,7 @@
                         {@const duration = episode.duration}
 
                         <a
-                            href="{remove_slash_from_end($page.url.pathname)}/episode/{episode_number}"
+                            href="{get_page_from_url($page.url.pathname)}/episode/{episode_number}"
                             class="relative col-span-12 grid grid-cols-12 gap-4 md:col-span-4"
                         >
                             <card-banner-info class="relative col-span-5 h-full w-full md:col-span-12 md:h-[19vw]">

--- a/src/lib/components/pages/episode/index.svelte
+++ b/src/lib/components/pages/episode/index.svelte
@@ -19,7 +19,7 @@
     import { blur } from "svelte/transition";
     import tippy from "tippy.js";
     import { page } from "$app/stores";
-    import { remove_slash_from_end } from "$functions/urls/remove_slash_at_end";
+    import { get_page_from_url } from "$functions/urls/get_page_from_url";
 
     /* Comment section logics */
     let comment_body: string;
@@ -55,19 +55,19 @@
             options: {
                 download: {
                     component: Download,
-                    link: `${remove_slash_from_end($page.url.pathname)}`,
+                    link: `${get_page_from_url($page.url.pathname)}`,
                     class: "w-4 md:w-[1.4vw]",
                     text: "Download"
                 },
                 prev: {
                     component: Next,
-                    link: `${remove_slash_from_end($page.url.pathname)}`,
+                    link: `${get_page_from_url($page.url.pathname)}`,
                     class: "w-4 md:w-[1.4vw] rotate-180",
                     text: "Previous Episode"
                 },
                 next: {
                     component: Next,
-                    link: `${remove_slash_from_end($page.url.pathname)}`,
+                    link: `${get_page_from_url($page.url.pathname)}`,
                     class: "w-4 md:w-[1.4vw]",
                     text: "Next Episode"
                 }
@@ -182,7 +182,7 @@
                     {@const actual_index = index + 1}
                     {@const button_active = actual_index === episode_number}
                     <a
-                        href="{remove_slash_from_end($page.url.pathname)}/{actual_index}"
+                        href="{get_page_from_url($page.url.pathname)}/{actual_index}"
                         class="{button_active ? 'bg-primary-500' : 'bg-surface-400'} btn rounded py-3 text-sm font-semibold leading-none md:rounded-[0.35vw] md:py-[0.75vw] md:text-[1.2vw]"
                     >
                         {actual_index}
@@ -239,7 +239,7 @@
         <next-episode class="col-span-4 hidden flex-col md:flex">
             <span class="font-semibold uppercase md:text-[1.1vw]">next episode</span>
             <a
-                href="{remove_slash_from_end($page.url.pathname)}/{episode_number + 1}"
+                href="{get_page_from_url($page.url.pathname)}/{episode_number + 1}"
                 class="flex md:mt-[0.75vw] md:gap-[1vw]"
             >
                 <episode-cover class="relative">

--- a/src/lib/components/pages/home/latest_episodes_card.svelte
+++ b/src/lib/components/pages/home/latest_episodes_card.svelte
@@ -3,7 +3,7 @@
     import ImageLoader from "$components/shared/image/image_loader.svelte";
     import ScrollArea from "$components/shared/scroll_area.svelte";
     import { FormatDate } from "$functions/format_date";
-    import { remove_slash_from_end } from "$functions/urls/remove_slash_at_end";
+    import { get_page_from_url } from "$functions/urls/get_page_from_url";
     import Play from "$icons/play.svelte";
     import { onMount } from "svelte";
     import { slide } from "svelte/transition";
@@ -97,7 +97,7 @@
             </episode-dates>
         </div>
         <a
-            href="{remove_slash_from_end($page.url.pathname)}/mal/{anime.id}/episode/{anime.episode_number}"
+            href="{get_page_from_url($page.url.pathname)}/mal/{anime.id}/episode/{anime.episode_number}"
             class="btn btn-icon h-[2.5vw] w-[2.5vw] rounded-full bg-warning-400 text-surface-900 transition-colors duration-300 group-hover:bg-white"
         >
             <Play class="w-[1.25vw]" />

--- a/src/lib/components/tippies/anime_card.svelte
+++ b/src/lib/components/tippies/anime_card.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
     import ScrollArea from "$components/shared/scroll_area.svelte";
+    import { get_page_from_url } from "$functions/urls/get_page_from_url";
+    import { page } from "$app/stores";
     import Circle from "$icons/circle.svelte";
     import Info from "$icons/info.svelte";
     import PlayCircle from "$icons/play_circle.svelte";
@@ -49,14 +51,14 @@
 
         <options class="flex items-center border-t-[0.1vw] border-white/10 md:mt-[0.25vw] md:gap-[0.5vw] md:pt-[0.75vw]">
             <a
-                href="./mal/{anime_id}/episode/1"
+                href="{get_page_from_url($page.url.pathname)}/mal/{anime_id}/episode/1"
                 class="btn h-[2.3vw] flex-1 bg-primary-500 leading-none md:rounded-[0.5vw]"
             >
                 <PlayCircle class="md:w-[1vw]" />
                 <span class="font-semibold md:text-[0.9vw]">Watch Ep 1</span>
             </a>
             <a
-                href="./mal/{anime_id}"
+                href="{get_page_from_url($page.url.pathname)}/mal/{anime_id}"
                 class="btn aspect-square h-[2.3vw] bg-primary-500/25 p-0 leading-none md:rounded-[0.5vw]"
             >
                 <Info class="md:w-[1.2vw]" />

--- a/src/lib/components/tippies/my_list_anime_details.svelte
+++ b/src/lib/components/tippies/my_list_anime_details.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
     import ScrollArea from "$components/shared/scroll_area.svelte";
-    import { remove_slash_from_end } from "$functions/urls/remove_slash_at_end";
     import { page } from "$app/stores";
     import Circle from "$icons/circle.svelte";
     import Info from "$icons/info.svelte";
     import PlayCircle from "$icons/play_circle.svelte";
     import Star from "$icons/star.svelte";
+    import { get_page_from_url } from "$functions/urls/get_page_from_url";
 
     export let anime_id: number, anime_name: string, anime_episodes_count: number, anime_current_episode: number, anime_type: string, anime_genres: string[], anime_studios: string[], anime_synopsis: string;
 </script>
@@ -51,14 +51,14 @@
 
         <options class="flex items-center border-t-[0.1vw] border-white/10 md:mt-[0.25vw] md:gap-[0.5vw] md:pt-[0.75vw]">
             <a
-                href="{remove_slash_from_end($page.url.pathname)}/mal/{anime_id}/episode/{anime_current_episode}"
+                href="{get_page_from_url($page.url.pathname)}/mal/{anime_id}/episode/{anime_current_episode}"
                 class="btn h-[2.3vw] flex-1 bg-primary-500 leading-none md:rounded-[0.5vw]"
             >
                 <PlayCircle class="md:w-[0.9vw]" />
                 <span class="font-semibold md:text-[0.9vw]">Continue Ep {anime_current_episode}</span>
             </a>
             <a
-                href="{remove_slash_from_end($page.url.pathname)}/mal/{anime_id}"
+                href="{get_page_from_url($page.url.pathname)}/mal/{anime_id}"
                 class="btn aspect-square h-[2.3vw] bg-primary-500/25 p-0 leading-none md:rounded-[0.5vw]"
             >
                 <Info class="md:w-[1.2vw]" />

--- a/src/lib/functions/urls/get_page_from_url.test.ts
+++ b/src/lib/functions/urls/get_page_from_url.test.ts
@@ -1,0 +1,6 @@
+import { test, expect } from "vitest";
+import { get_page_from_url } from "./get_page_from_url";
+
+test("get page from url", () => {
+	expect(get_page_from_url("/anime/mal/1/episode/1")).toBe("/anime");
+})

--- a/src/lib/functions/urls/get_page_from_url.ts
+++ b/src/lib/functions/urls/get_page_from_url.ts
@@ -1,0 +1,6 @@
+export function get_page_from_url(url: string): string {
+	const endpoints = url.split("/").filter(Boolean); // removes empty string
+	const page = `/${endpoints[0]}`;
+
+	return page;
+};

--- a/src/lib/functions/urls/remove_slash_at_end.test.ts
+++ b/src/lib/functions/urls/remove_slash_at_end.test.ts
@@ -1,6 +1,0 @@
-import { remove_slash_from_end } from "$functions/urls/remove_slash_at_end";
-import { test, expect } from "vitest";
-
-test("remove trailing slash", () => {
-    expect(remove_slash_from_end("https://hello.world/remove_slash_from_end/")).toBe("https://hello.world/remove_slash_from_end");
-});

--- a/src/lib/functions/urls/remove_slash_at_end.ts
+++ b/src/lib/functions/urls/remove_slash_at_end.ts
@@ -1,6 +1,0 @@
-export function remove_slash_from_end(url: string): string {
-    /** Credit
-     * https://www.designcise.com/web/tutorial/how-to-remove-a-trailing-slash-from-a-string-in-javascript#using-endswith
-     */
-    return url.endsWith("/") ? url.slice(0, -1) : url;
-}

--- a/src/routes/anime/+page.svelte
+++ b/src/routes/anime/+page.svelte
@@ -31,7 +31,7 @@
     import { blur } from "svelte/transition";
     import tippy from "tippy.js";
     import LatestEpisodesCard from "$components/pages/home/latest_episodes_card.svelte";
-    import { remove_slash_from_end } from "$functions/urls/remove_slash_at_end";
+    import { get_page_from_url } from "$functions/urls/get_page_from_url";
 
     const slider_delay = 10,
         timer = new EasyTimer({
@@ -286,7 +286,7 @@
                                     <span>Ep 1</span>
                                 </button>
 
-                                <a href="{remove_slash_from_end($page.url.pathname)}/mal/{anime.mal_id}">
+                                <a href="{get_page_from_url($page.url.pathname)}/mal/{anime.mal_id}">
                                     <button class="btn btn-icon flex h-14 w-28 items-center justify-center rounded-xl bg-surface-900 text-base font-semibold text-surface-50 md:h-[3.125vw] md:w-[6.5vw] md:rounded-[0.5vw] md:text-[0.875vw] md:font-bold">
                                         <Info class="w-5 text-surface-50 md:w-[1.25vw]" />
                                         <span>Details</span>
@@ -476,7 +476,7 @@
         >
             {#each my_list as anime}
                 <a
-                    href="{remove_slash_from_end($page.url.pathname)}/mal/{anime.id}/episode/{anime.current_episode}"
+                    href="{get_page_from_url($page.url.pathname)}/mal/{anime.id}/episode/{anime.current_episode}"
                     class="relative"
                     use:tippy={{
                         arrow: false,

--- a/src/routes/anime/explore/+page.svelte
+++ b/src/routes/anime/explore/+page.svelte
@@ -17,6 +17,12 @@
     import SixGrids from "$icons/six_grids.svelte";
     import { scale } from "svelte/transition";
     import HoverExpand from "$components/shared/hover_expand.svelte";
+    import { onMount } from "svelte";
+    import { get_page_from_url } from "$functions/urls/get_page_from_url";
+    
+    onMount(() => {
+        console.log(get_page_from_url($page.url.pathname));
+    })
 
     /* Bindings */
     let result_animes_element: HTMLElement;
@@ -286,7 +292,7 @@
                 {#each trending_animes as anime}
                     <a
                         in:scale={{ start: 0.95 }}
-                        href="/mal/{anime.id}"
+                        href="{get_page_from_url($page.url.pathname)}/mal/{anime.id}"
                         class="relative col-span-1 grid grid-cols-1 md:grid-cols-2"
                     >
                         <div class="relative">
@@ -349,7 +355,7 @@
                 {#each trending_animes as anime}
                     <a
                         in:scale={{ start: 0.95 }}
-                        href="/mal/{anime.id}"
+                        href="{get_page_from_url($page.url.pathname)}/mal/{anime.id}"
                         class="relative col-span-1 flex flex-col gap-2 md:gap-[0.5vw]"
                     >
                         <div

--- a/src/routes/user/login/1.svelte
+++ b/src/routes/user/login/1.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { page } from "$app/stores";
-    import { remove_slash_from_end } from "$functions/urls/remove_slash_at_end";
+    import { get_page_from_url } from "$functions/urls/get_page_from_url";
     import ArrowUpRight from "$icons/arrow_up_right.svelte";
     import Info from "$icons/info.svelte";
     import { reporter } from "@felte/reporter-svelte";
@@ -79,7 +79,7 @@
 
         <div class="flex flex-col items-start md:mt-[3vw]">
             <a
-                href="{remove_slash_from_end($page.url.pathname)}/reset-password"
+                href="{get_page_from_url($page.url.pathname)}/reset-password"
                 class="btn p-0 text-base font-semibold leading-none text-primary-600 underline md:text-[1vw]"
             >
                 {@html `< forgot password? >`}
@@ -91,7 +91,7 @@
         <div class="flex flex-col gap-1 md:gap-[0.5vw]">
             <span class="text-xs leading-none text-surface-100 md:text-[0.75vw]">Don't have a core account?</span>
             <a
-                href="{remove_slash_from_end($page.url.pathname)}/register"
+                href="{get_page_from_url($page.url.pathname)}/register"
                 class="text-base leading-none md:text-[1.1vw]"
             >
                 Register

--- a/src/routes/user/login/2.svelte
+++ b/src/routes/user/login/2.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { page } from "$app/stores";
-    import { remove_slash_from_end } from "$functions/urls/remove_slash_at_end";
+    import { get_page_from_url } from "$functions/urls/get_page_from_url";
     import ArrowUpRight from "$icons/arrow_up_right.svelte";
     import Info from "$icons/info.svelte";
     import { focusTrap } from "@skeletonlabs/skeleton";
@@ -48,7 +48,7 @@
         <div class="flex flex-col gap-1 md:gap-0">
             <span class="text-xs text-surface-100 md:text-[0.75vw]">Don't have a core account?</span>
             <a
-                href="{remove_slash_from_end($page.url.pathname)}/register"
+                href="{get_page_from_url($page.url.pathname)}/register"
                 class="text-base md:text-[1.1vw]"
             >
                 Register

--- a/src/routes/user/register/1.svelte
+++ b/src/routes/user/register/1.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { page } from "$app/stores";
-    import { remove_slash_from_end } from "$functions/urls/remove_slash_at_end";
+    import { get_page_from_url } from "$functions/urls/get_page_from_url";
     import ArrowUpRight from "$icons/arrow_up_right.svelte";
     import Cross from "$icons/cross.svelte";
     import Info from "$icons/info.svelte";
@@ -241,7 +241,7 @@
         <div class="flex flex-col gap-1 md:gap-[0.5vw]">
             <span class="text-xs text-surface-100 md:text-[0.75vw]">Already have an account?</span>
             <a
-                href="{remove_slash_from_end($page.url.pathname)}/login"
+                href="{get_page_from_url($page.url.pathname)}/login"
                 class="text-base leading-none md:text-[1.1vw]"
             >
                 Login

--- a/src/routes/user/register/2.svelte
+++ b/src/routes/user/register/2.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { page } from "$app/stores";
-    import { remove_slash_from_end } from "$functions/urls/remove_slash_at_end";
+    import { get_page_from_url } from "$functions/urls/get_page_from_url";
     import ArrowUpRight from "$icons/arrow_up_right.svelte";
     import Info from "$icons/info.svelte";
     import { ValidationMessage, reporter } from "@felte/reporter-svelte";
@@ -111,7 +111,7 @@
         <div class="flex flex-col gap-1 md:gap-0">
             <span class="text-xs text-surface-100 md:text-[0.75vw]">Already have an account?</span>
             <a
-                href="{remove_slash_from_end($page.url.pathname)}/login"
+                href="{get_page_from_url($page.url.pathname)}/login"
                 class="text-base md:text-[1.1vw]"
             >
                 Login

--- a/src/routes/user/register/3.svelte
+++ b/src/routes/user/register/3.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { page } from "$app/stores";
-    import { remove_slash_from_end } from "$functions/urls/remove_slash_at_end";
+    import { get_page_from_url } from "$functions/urls/get_page_from_url";
     import Tick from "$icons/tick.svelte";
     import { focusTrap } from "@skeletonlabs/skeleton";
     import { createForm } from "felte";
@@ -86,7 +86,7 @@
         <div class="flex flex-col gap-1 md:gap-0">
             <span class="text-xs text-surface-100 md:text-[0.75vw]">Already have an account?</span>
             <a
-                href="{remove_slash_from_end($page.url.pathname)}/login"
+                href="{get_page_from_url($page.url.pathname)}/login"
                 class="text-base md:text-[1.1vw]"
             >
                 Login

--- a/src/routes/user/reset-password/+page.svelte
+++ b/src/routes/user/reset-password/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { page } from "$app/stores";
-    import { remove_slash_from_end } from "$functions/urls/remove_slash_at_end";
+    import { get_page_from_url } from "$functions/urls/get_page_from_url";
     import ArrowUpRight from "$icons/arrow_up_right.svelte";
     import Info from "$icons/info.svelte";
     import { focusTrap } from "@skeletonlabs/skeleton";
@@ -38,7 +38,7 @@
         <div class="flex flex-col gap-1 md:gap-0">
             <span class="text-xs text-surface-100 md:text-[0.75vw]">Don't have a core account?</span>
             <a
-                href="{remove_slash_from_end($page.url.pathname)}/register"
+                href="{get_page_from_url($page.url.pathname)}/register"
                 class="text-base md:text-[1.1vw]"
             >
                 Register


### PR DESCRIPTION
Created this function to get `page` from long urls.
eg: returns `/anime` from `/anime/mal/1/sheldon`

Needed to create this since some tippies redirect link is not correct and needed to bind manually.
also this removes `remove_slash_from_end` function ( no need since this function removes it )

Fixes relative link issues in https://github.com/tokitou-san/CoreProject-V3-UI/pull/682