### PR TITLE
refactor: rewrite `Hoverexpand` styles in tailwind

### DIFF
--- a/src/lib/components/shared/hover_expand.svelte
+++ b/src/lib/components/shared/hover_expand.svelte
@@ -9,7 +9,7 @@
     export let line_clamp: number = 1;
 </script>
 
-<ScrollArea class="{cn( klass, height, duration )} overflow-hidden ease-in-out scrollbar-none hover:overflow-y-scroll">
+<ScrollArea class={cn(klass, height, duration, "overflow-hidden ease-in-out scrollbar-none hover:overflow-y-scroll")}>
     <span class="line-clamp-{line_clamp} md:line-clamp-none [&:not(:hover)]:[mask-image:_linear-gradient(90deg,_rgba(7,5,25)_75%,_rgba(0,0,0,0)_100%)]">
         <slot />
     </span>

--- a/src/lib/components/shared/hover_expand.svelte
+++ b/src/lib/components/shared/hover_expand.svelte
@@ -10,17 +10,7 @@
 </script>
 
 <ScrollArea class="{cn( klass, height, duration )} overflow-hidden ease-in-out scrollbar-none hover:overflow-y-scroll">
-    <span class="line-clamp-{line_clamp} md:line-clamp-none mask-right">
+    <span class="line-clamp-{line_clamp} md:line-clamp-none [&:not(:hover)]:[mask-image:_linear-gradient(90deg,_rgba(7,5,25)_75%,_rgba(0,0,0,0)_100%)]">
         <slot />
     </span>
 </ScrollArea>
-
-<style lang="scss">
-    .mask-right {
-        &:not(:hover) {
-            /* if we need to change the width, we should change the 75% to higher  */
-            mask-image: linear-gradient(90deg, rgba(7, 5, 25) 75%, rgba(0, 0, 0, 0) 100%);
-            mask-position: right;
-        }
-    }
-</style>


### PR DESCRIPTION
Rewrite `Hoverexpand` styles into Tailwind class ( arbitrary style )
Closes #674 